### PR TITLE
Hook execution order

### DIFF
--- a/src/vmq_plugin_helper.erl
+++ b/src/vmq_plugin_helper.erl
@@ -21,7 +21,7 @@ all(Hooks, Params) ->
 all([{Module, Fun}|Rest], Params, Acc) ->
     Res = apply(Module, Fun, Params),
     all(Rest, Params, [Res|Acc]);
-all([], _, Acc) -> Acc.
+all([], _, Acc) -> lists:reverse(Acc).
 
 all_till_ok(Hooks, Params) ->
     all_till_ok(Hooks, Params, []).

--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -281,7 +281,7 @@ enable_plugin_generic(Plugin, #state{config_file=ConfigFile} = State) ->
             NewPlugins =
             case lists:keyfind(Key, 2, Plugins) of
                 false ->
-                    [Plugin|Plugins];
+                    Plugins ++ [Plugin];
                 Plugin ->
                     Plugins;
                 _OldInstance ->
@@ -394,7 +394,7 @@ check_plugins([{application, App, AppPath}|Rest], Acc) ->
     end;
 
 check_plugins([], CheckedHooks) ->
-    {ok, CheckedHooks}.
+    {ok, lists:reverse(CheckedHooks)}.
 
 start_plugins([{module_plugin, _}|Rest]) ->
     start_plugins(Rest);
@@ -534,7 +534,7 @@ check_hooks(App, [{Name, Module, Fun, Arity}|Rest], Acc) ->
     end;
 check_hooks(App, [_|Rest], Acc) ->
     check_hooks(App, Rest, Acc);
-check_hooks(_, [], Acc) -> Acc.
+check_hooks(_, [], Acc) -> lists:reverse(Acc).
 
 check_hook(Module, Fun, Arity) ->
     case catch apply(Module, module_info, [exports]) of
@@ -608,7 +608,7 @@ all_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc, Info) ->
              [{atom, 1, vmq_plugin_helper},
               {atom, 1, all},
               {cons, 1,
-               list_const(false, lists:reverse([Hook|Hooks])),
+               list_const(false, [Hook|Hooks]),
                {cons, 1,
                 {var, 1, 'Params'},
                 {nil, 1}}}]
@@ -627,7 +627,7 @@ all_till_ok_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc) ->
              [{atom, 1, vmq_plugin_helper},
               {atom, 1, all_till_ok},
               {cons, 1,
-               list_const(false, lists:reverse([Hook|Hooks])),
+               list_const(false, [Hook|Hooks]),
                {cons, 1,
                 {var, 1, 'Params'},
                 {nil, 1}}}]

--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -749,15 +749,35 @@ vmq_plugin_test() ->
     ?assertEqual(ok, vmq_plugin_mgr:enable_plugin(vmq_plugin, "..")),
     ?assert(lists:keyfind(vmq_plugin, 1, application:which_applications()) /= false),
 
-    call_hooks(),
-
     io:format(user, "info all ~p~n", [vmq_plugin:info(all)]),
     io:format(user, "info only ~p~n", [vmq_plugin:info(only)]),
+
+    %% the plugins are sorted (stable) by the plugin name.
+    ?assertEqual([{sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1},
+                  {sample_all_hook,vmq_plugin_mgr,other_sample_hook_b,1},
+                  {sample_all_hook,vmq_plugin_mgr,other_sample_hook_c,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_d,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_e,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_f,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_x,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,0},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,2},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,3}], vmq_plugin:info(all)),
+
+    %% the plugins are sorted (stable) by the plugin name.
+    ?assertEqual([{sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_d,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,0},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,2},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,3}], vmq_plugin:info(only)),
+
+    call_hooks(),
+
 
     %% Disable Plugin
     ?assertEqual(ok, vmq_plugin_mgr:disable_plugin(vmq_plugin)),
-    io:format(user, "info all ~p~n", [vmq_plugin:info(all)]),
-    io:format(user, "info only ~p~n", [vmq_plugin:info(only)]),
     %% no plugin is registered
     call_no_hooks().
 
@@ -776,10 +796,30 @@ vmq_module_plugin_test() ->
     vmq_plugin_mgr:enable_module_plugin(sample_all_till_ok_hook, ?MODULE, other_sample_hook_e, 1),
     vmq_plugin_mgr:enable_module_plugin(sample_all_till_ok_hook, ?MODULE, other_sample_hook_f, 1),
     vmq_plugin_mgr:enable_module_plugin(sample_all_till_ok_hook, ?MODULE, other_sample_hook_x, 1),
+
+    %% the plugins are sorted (stable) by the plugin name.
+    ?assertEqual([{sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1},
+                  {sample_all_hook,vmq_plugin_mgr,other_sample_hook_b,1},
+                  {sample_all_hook,vmq_plugin_mgr,other_sample_hook_c,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_d,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_e,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_f,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_x,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,0},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,2},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,3}], vmq_plugin:info(all)),
+
+    %% the plugins are sorted (stable) by the plugin name.
+    ?assertEqual([{sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1},
+                  {sample_all_till_ok_hook,vmq_plugin_mgr,other_sample_hook_d,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,0},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,1},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,2},
+                  {sample_hook,vmq_plugin_mgr,sample_hook,3}], vmq_plugin:info(only)),
+
     call_hooks(),
 
-    io:format(user, "info all ~p~n", [vmq_plugin:info(all)]),
-    io:format(user, "info only ~p~n", [vmq_plugin:info(only)]),
     % disable hooks
     vmq_plugin_mgr:disable_module_plugin(?MODULE, sample_hook, 0),
     vmq_plugin_mgr:disable_module_plugin(?MODULE, sample_hook, 1),

--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -392,7 +392,6 @@ check_plugins([{application, App, AppPath}|Rest], Acc) ->
         CheckedHooks ->
             check_plugins(Rest, [{App, CheckedHooks} | Acc])
     end;
-
 check_plugins([], CheckedHooks) ->
     {ok, lists:reverse(CheckedHooks)}.
 
@@ -566,13 +565,13 @@ info_only_clause(Hooks) ->
     {clause, 1,
      [{atom, 1, only}],
      [],
-     [list_const(true, lists:reverse(Hooks))]
+     [list_const(true, Hooks)]
     }.
 info_all_clause(Hooks) ->
     {clause, 2,
      [{atom, 1, all}],
      [],
-     [list_const(true, lists:reverse(Hooks))]
+     [list_const(true, Hooks)]
     }.
 
 
@@ -613,9 +612,9 @@ all_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc, Info) ->
                 {var, 1, 'Params'},
                 {nil, 1}}}]
             }]),
-    all_clauses(I + 1, Rest -- Hooks, [Clause|Acc], lists:reverse([Hook|Hooks]) ++ Info);
+    all_clauses(I + 1, Rest -- Hooks, [Clause|Acc], Info ++ [Hook|Hooks]);
 all_clauses(I, [], Acc, Info) ->
-    {lists:reverse([not_found_clause(I) | Acc]), lists:reverse(Info)}.
+    {lists:reverse([not_found_clause(I) | Acc]), Info}.
 
 
 all_till_ok_clauses(I, [{Name, _, _, Arity} = Hook |Rest], Acc) ->


### PR DESCRIPTION
This PR strengthens the tests for the vmq plugin manager by adding tests that check the order of hook execution, ie., that a hook with multiple functions registered executes and returns the values in the same order as the hooks where registered.
