### PR TITLE
Internal plugins

### DIFF
--- a/src/vmq_plugin_cli.erl
+++ b/src/vmq_plugin_cli.erl
@@ -19,8 +19,7 @@
 
 register_cli() ->
     vmq_plugin_cli_usage(),
-    vmq_plugin_show_cmd(["vmq-admin", "plugin", "show"], false),
-    vmq_plugin_show_cmd(["vmq-admin", "plugin", "show", "internal"], true),
+    vmq_plugin_show_cmd(),
     vmq_plugin_enable_cmd(),
     vmq_plugin_disable_cmd(),
     ok.
@@ -28,21 +27,23 @@ register_cli() ->
 vmq_plugin_cli_usage() ->
     clique:register_usage(["vmq-admin", "plugin"], plugin_usage()),
     clique:register_usage(["vmq-admin", "plugin", "show"], plugin_show_usage()),
-    clique:register_usage(["vmq-admin", "plugin", "show", "internal"], plugin_show_internal_usage()),
     clique:register_usage(["vmq-admin", "plugin", "enable"], plugin_enable_usage()),
     clique:register_usage(["vmq-admin", "plugin", "disable"], plugin_disable_usage()).
 
-vmq_plugin_show_cmd(Cmd, ShowInternal) ->
+vmq_plugin_show_cmd() ->
+    Cmd = ["vmq-admin", "plugin", "show"],
     KeySpecs = [],
     FlagSpecs = [{plugin, [{longname, "plugin"},
                            {typecast, fun(P) -> list_to_atom(P) end}]},
                  {hook, [{longname, "hook"},
-                         {typecast, fun(H) -> list_to_atom(H) end}]}],
+                         {typecast, fun(H) -> list_to_atom(H) end}]},
+                 {internal, [{longname, "internal"}]}],
     Callback =
     fun([], Flags) ->
             Plugins = extract_table(vmq_plugin:info(raw)),
             PluginName = proplists:get_value(plugin, Flags, []),
             HookName = proplists:get_value(hook, Flags, []),
+            ShowInternal = proplists:get_value(internal, Flags, false),
             FilteredPlugins =
                 lists:filtermap(
                   fun({_, module, _}) when not ShowInternal ->
@@ -232,23 +233,13 @@ plugin_usage() ->
 plugin_show_usage() ->
     ["vmq-admin plugin show\n\n",
      "  Shows the currently running plugins.\n\n",
-     "  Sub-commands:\n",
-     "    internal      also show internal plugins\n\n"
      "Options\n\n",
      "  --plugin\n",
      "      Only shows the hooks for the specified plugin\n",
      "  --hook\n",
-     "      Only shows the plugins that provide callbacks for the specified hook\n"
-    ].
-
-plugin_show_internal_usage() ->
-    ["vmq-admin plugin show\n\n",
-     "  Shows all currently running plugins, including internal plugins.\n\n",
-     "Options\n\n",
-     "  --plugin\n",
-     "      Only shows the hooks for the specified plugin\n",
-     "  --hook\n",
-     "      Only shows the plugins that provide callbacks for the specified hook\n"
+     "      Only shows the plugins that provide callbacks for the specified hook\n",
+     "  --internal\n",
+     "      Also show internal plugins\n"
     ].
 
 plugin_enable_usage() ->

--- a/src/vmq_plugin_cli.erl
+++ b/src/vmq_plugin_cli.erl
@@ -19,7 +19,8 @@
 
 register_cli() ->
     vmq_plugin_cli_usage(),
-    vmq_plugin_show_cmd(),
+    vmq_plugin_show_cmd(["vmq-admin", "plugin", "show"], false),
+    vmq_plugin_show_cmd(["vmq-admin", "plugin", "show", "internal"], true),
     vmq_plugin_enable_cmd(),
     vmq_plugin_disable_cmd(),
     ok.
@@ -27,11 +28,11 @@ register_cli() ->
 vmq_plugin_cli_usage() ->
     clique:register_usage(["vmq-admin", "plugin"], plugin_usage()),
     clique:register_usage(["vmq-admin", "plugin", "show"], plugin_show_usage()),
+    clique:register_usage(["vmq-admin", "plugin", "show", "internal"], plugin_show_internal_usage()),
     clique:register_usage(["vmq-admin", "plugin", "enable"], plugin_enable_usage()),
     clique:register_usage(["vmq-admin", "plugin", "disable"], plugin_disable_usage()).
 
-vmq_plugin_show_cmd() ->
-    Cmd = ["vmq-admin", "plugin", "show"],
+vmq_plugin_show_cmd(Cmd, ShowInternal) ->
     KeySpecs = [],
     FlagSpecs = [{plugin, [{longname, "plugin"},
                            {typecast, fun(P) -> list_to_atom(P) end}]},
@@ -42,7 +43,6 @@ vmq_plugin_show_cmd() ->
             Plugins = extract_table(vmq_plugin:info(raw)),
             PluginName = proplists:get_value(plugin, Flags, []),
             HookName = proplists:get_value(hook, Flags, []),
-            ShowInternal = false,
             FilteredPlugins =
                 lists:filtermap(
                   fun({_, module, _}) when not ShowInternal ->
@@ -232,6 +232,18 @@ plugin_usage() ->
 plugin_show_usage() ->
     ["vmq-admin plugin show\n\n",
      "  Shows the currently running plugins.\n\n",
+     "  Sub-commands:\n",
+     "    internal      also show internal plugins\n\n"
+     "Options\n\n",
+     "  --plugin\n",
+     "      Only shows the hooks for the specified plugin\n",
+     "  --hook\n",
+     "      Only shows the plugins that provide callbacks for the specified hook\n"
+    ].
+
+plugin_show_internal_usage() ->
+    ["vmq-admin plugin show\n\n",
+     "  Shows all currently running plugins, including internal plugins.\n\n",
      "Options\n\n",
      "  --plugin\n",
      "      Only shows the hooks for the specified plugin\n",

--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -585,9 +585,13 @@ check_app_hooks(App, Hooks, Options) ->
             {error, Reason}
     end.
 
+check_app_hooks(App, [{Module, Fun, Arity}|Rest]) ->
+    check_app_hooks(App, [{Module, Fun, Arity, []}|Rest]);
 check_app_hooks(App, [{Module, Fun, Arity, Opts}|Rest])
   when is_list(Opts) ->
     check_app_hooks(App, [{Fun, Module, Fun, Arity, Opts}|Rest]);
+check_app_hooks(App, [{HookName, Module, Fun, Arity}|Rest]) ->
+    check_app_hooks(App, [{HookName, Module, Fun, Arity, []}|Rest]);
 check_app_hooks(App, [{_HookName, Module, Fun, Arity, Opts}|Rest])
   when is_list(Opts) ->
     case check_mfa(Module, Fun, Arity) of
@@ -618,8 +622,12 @@ extract_hooks([{application, _Name, Options}|Rest], Acc) ->
     end.
 
 extract_app_hooks([], Acc) -> Acc;
+extract_app_hooks([{Mod, Fun, Arity}|Rest], Acc) ->
+    extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity, []}|Acc]);
 extract_app_hooks([{Mod, Fun, Arity, Opts}|Rest], Acc) when is_list(Opts) ->
     extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity, Opts}|Acc]);
+extract_app_hooks([{H,M,F,A}|Rest], Acc) ->
+    extract_app_hooks([{H,M,F,A,[]}|Rest], Acc);
 extract_app_hooks([{H,M,F,A, Opts}|Rest], Acc) ->
     extract_app_hooks(Rest, [{H,M,F,A, Opts}|Acc]).
 

--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -305,9 +305,12 @@ get_new_hooks({application, Name, Opts}, OldPlugins) ->
         false -> {application, Name, Opts}
     end.
 
-plugins_have_hook({H, M, F, A}, OldPlugins) ->
-    Hooks = extract_hooks(OldPlugins),
-    lists:member({H,M,F,A}, Hooks).
+plugins_have_hook(Hook, OldPlugins) ->
+    lists:any(
+      fun({H,M,F,A,_}) ->
+              {H,M,F,A} =:= Hook
+      end,
+      extract_hooks(OldPlugins)).
 
 disable_plugin_generic(PluginKey, #state{config_file=ConfigFile} = State) ->
     case file:consult(ConfigFile) of
@@ -582,9 +585,11 @@ check_app_hooks(App, Hooks, Options) ->
             {error, Reason}
     end.
 
-check_app_hooks(App, [{Module, Fun, Arity}|Rest]) ->
-    check_app_hooks(App, [{Fun, Module, Fun, Arity}|Rest]);
-check_app_hooks(App, [{_HookName, Module, Fun, Arity}|Rest]) ->
+check_app_hooks(App, [{Module, Fun, Arity, Opts}|Rest])
+  when is_list(Opts) ->
+    check_app_hooks(App, [{Fun, Module, Fun, Arity, Opts}|Rest]);
+check_app_hooks(App, [{_HookName, Module, Fun, Arity, Opts}|Rest])
+  when is_list(Opts) ->
     case check_mfa(Module, Fun, Arity) of
         ok ->
             check_app_hooks(App, Rest);
@@ -593,8 +598,6 @@ check_app_hooks(App, [{_HookName, Module, Fun, Arity}|Rest]) ->
                         [Module, App, Reason]),
             {error, Reason}
     end;
-check_app_hooks(App, [_|Rest]) ->
-    check_app_hooks(App, Rest);
 check_app_hooks(_, []) -> hooks_ok.
 
 extract_hooks(CheckedPlugins) ->
@@ -615,21 +618,22 @@ extract_hooks([{application, _Name, Options}|Rest], Acc) ->
     end.
 
 extract_app_hooks([], Acc) -> Acc;
-extract_app_hooks([{Mod, Fun, Arity}|Rest], Acc) ->
-    extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity}|Acc]);
-extract_app_hooks([{_,_,_,_}=Hook|Rest], Acc) ->
-    extract_app_hooks(Rest, [Hook|Acc]).
+extract_app_hooks([{Mod, Fun, Arity, Opts}|Rest], Acc) when is_list(Opts) ->
+    extract_app_hooks(Rest, [{Fun, Mod, Fun, Arity, Opts}|Acc]);
+extract_app_hooks([{H,M,F,A, Opts}|Rest], Acc) ->
+    extract_app_hooks(Rest, [{H,M,F,A, Opts}|Acc]).
 
 extract_module_hooks(_, [], Acc) ->
     Acc;
 extract_module_hooks(ModName, [{HookName, Fun, Arity}|Rest], Acc) ->
-    extract_module_hooks(ModName, Rest, [{HookName, ModName, Fun, Arity}|Acc]);
+    extract_module_hooks(ModName, Rest, [{HookName, ModName, Fun, Arity, []}|Acc]);
 extract_module_hooks(ModName, [{Fun, Arity}|Rest], Acc) ->
-    extract_module_hooks(ModName, Rest, [{Fun, ModName, Fun, Arity}|Acc]).
+    extract_module_hooks(ModName, Rest, [{Fun, ModName, Fun, Arity, []}|Acc]).
 
 compile_hooks(CheckedPlugins) ->
-    CheckedHooks = extract_hooks(CheckedPlugins),
-    Hooks = lists:keysort(1, lists:flatten(CheckedHooks)),
+    RawPlugins = extract_hooks(CheckedPlugins),
+    Hooks = [{H,M,F,A} || {H,M,F,A,_} <-
+                              lists:keysort(1, lists:flatten(RawPlugins))],
     M1 = smerl:new(vmq_plugin),
     {OnlyClauses, OnlyInfo} = only_clauses(1, Hooks, {nil, nil}, [], []),
     {ok, M2} = smerl:add_func(M1, {function, 1, only, 2, OnlyClauses}),
@@ -812,34 +816,34 @@ other_sample_hook_x(V) ->
 
 
 check_plugin_for_app_plugins_test() ->
-    Hooks = [{?MODULE, sample_hook, 0},
-             {?MODULE, sample_hook, 1},
-             {?MODULE, sample_hook, 2},
-             {?MODULE, sample_hook, 3},
-             {sample_all_hook, ?MODULE, other_sample_hook_a, 1},
-             {sample_all_hook, ?MODULE, other_sample_hook_b, 1},
-             {sample_all_hook, ?MODULE, other_sample_hook_c, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_d, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_e, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_f, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_x, 1}
+    Hooks = [{?MODULE, sample_hook, 0, []},
+             {?MODULE, sample_hook, 1, []},
+             {?MODULE, sample_hook, 2, []},
+             {?MODULE, sample_hook, 3, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_a, 1, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_b, 1, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_c, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_d, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_e, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_f, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_x, 1, []}
             ],
     application:load(vmq_plugin),
     application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
     {ok, CheckedPlugins} = check_plugins([{application, vmq_plugin, []}], []),
     ?assertEqual([{application,vmq_plugin,
                   [{hooks,
-                    [{vmq_plugin_mgr,sample_hook,0},
-                     {vmq_plugin_mgr,sample_hook,1},
-                     {vmq_plugin_mgr,sample_hook,2},
-                     {vmq_plugin_mgr,sample_hook,3},
-                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1},
-                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_b,1},
-                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_c,1},
-                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_d,1},
-                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_e,1},
-                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_f,1},
-                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_x,1}]}]}],
+                    [{vmq_plugin_mgr,sample_hook,0, []},
+                     {vmq_plugin_mgr,sample_hook,1, []},
+                     {vmq_plugin_mgr,sample_hook,2, []},
+                     {vmq_plugin_mgr,sample_hook,3, []},
+                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_a,1, []},
+                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_b,1, []},
+                     {sample_all_hook,vmq_plugin_mgr,other_sample_hook_c,1, []},
+                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_d,1, []},
+                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_e,1, []},
+                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_f,1, []},
+                     {sample_all_till_ok_hook,vmq_plugin_mgr, other_sample_hook_x,1, []}]}]}],
                  CheckedPlugins),
     application:unload(vmq_plugin).
 
@@ -854,17 +858,17 @@ check_plugin_for_module_plugin_test() ->
 
 vmq_plugin_test() ->
     application:load(vmq_plugin),
-    Hooks = [{?MODULE, sample_hook, 0},
-             {?MODULE, sample_hook, 1},
-             {?MODULE, sample_hook, 2},
-             {?MODULE, sample_hook, 3},
-             {sample_all_hook, ?MODULE, other_sample_hook_a, 1},
-             {sample_all_hook, ?MODULE, other_sample_hook_b, 1},
-             {sample_all_hook, ?MODULE, other_sample_hook_c, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_d, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_e, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_f, 1},
-             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_x, 1}
+    Hooks = [{?MODULE, sample_hook, 0, []},
+             {?MODULE, sample_hook, 1, []},
+             {?MODULE, sample_hook, 2, []},
+             {?MODULE, sample_hook, 3, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_a, 1, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_b, 1, []},
+             {sample_all_hook, ?MODULE, other_sample_hook_c, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_d, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_e, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_f, 1, []},
+             {sample_all_till_ok_hook, ?MODULE, other_sample_hook_x, 1, []}
             ],
     application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
     %% we have to step out .eunit

--- a/test/vmq_plugin_SUITE.erl
+++ b/test/vmq_plugin_SUITE.erl
@@ -120,7 +120,7 @@ module_plugin_function_does_not_exist(Config) ->
 app_plugin_mod_does_not_exist(Config) ->
     ok = write_config(Config, empty_plugin_config()),
     {ok, _} = application:ensure_all_started(vmq_plugin),
-    Hooks = [{nonexistent_mod,sample_hook,0}],
+    Hooks = [{nonexistent_mod,sample_hook,0, []}],
     application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
     {error, {unknown_module,nonexistent_mod}} =
         vmq_plugin_mgr:enable_plugin(vmq_plugin, [code:lib_dir(vmq_plugin)]).
@@ -128,7 +128,7 @@ app_plugin_mod_does_not_exist(Config) ->
 app_plugin_function_does_not_exist(Config) ->
     ok = write_config(Config, empty_plugin_config()),
     {ok, _} = application:ensure_all_started(vmq_plugin),
-    Hooks = [{?MODULE,nonexistent_fun,0}],
+    Hooks = [{?MODULE,nonexistent_fun,0, []}],
     application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
     {error, {no_matching_fun_in_module,vmq_plugin_SUITE,nonexistent_fun,0}} =
         vmq_plugin_mgr:enable_plugin(vmq_plugin, [code:lib_dir(vmq_plugin)]).

--- a/test/vmq_plugin_SUITE.erl
+++ b/test/vmq_plugin_SUITE.erl
@@ -6,6 +6,7 @@
          all/0]).
 
 -export([an_empty_config_file/1,
+         app_hook_without_proplist/1,
          load_plugin_config_file/1,
          bad_plugin_does_not_get_saved/1,
          good_plugin_gets_saved/1,
@@ -22,6 +23,7 @@
 
 all() ->
     [an_empty_config_file,
+     app_hook_without_proplist,
      load_plugin_config_file,
      bad_plugin_does_not_get_saved,
      good_plugin_gets_saved,
@@ -72,6 +74,15 @@ an_empty_config_file(Config) ->
     {ok, _} = application:ensure_all_started(vmq_plugin),
     %% Expect that no new plugins has been written to file.
     {plugins, []} = read_config(Config).
+
+
+app_hook_without_proplist(Config) ->
+    ok = write_config(Config, empty_plugin_config()),
+    {ok, _} = application:ensure_all_started(vmq_plugin),
+    Hooks = [{?MODULE, sample_hook_function, 0},
+             {hookname, ?MODULE, sample_hook_function, 0}],
+    application:set_env(vmq_plugin, vmq_plugin_hooks, Hooks),
+    ok = vmq_plugin_mgr:enable_plugin(vmq_plugin, [code:lib_dir(vmq_plugin)]).
 
 bad_plugin_does_not_get_saved(Config) ->
     ok = write_config(Config, empty_plugin_config()),


### PR DESCRIPTION
Make `vmq-admin` only show internal plugins (meaning app hooks marked as internal and modules) if the `internal` cmd is passed.

This depends on the three other pull requests:

https://github.com/erlio/vmq_passwd/pull/1
https://github.com/erlio/vmq_systree/pull/1
https://github.com/erlio/vmq_acl/pull/1
