### PR TITLE
Unload plugin application when plugin is disabled

### DIFF
--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -529,6 +529,7 @@ stop_plugin(App) ->
         false ->
             application:stop(App)
     end,
+    application:unload(App),
     ok.
 
 check_app_plugin(App, Options) ->


### PR DESCRIPTION
When disabling an application plugin the application must also be
unloaded. Otherwise the application is not loaded when the plugin is re-
enabled but only started. This means any new application config would be
ignored.
