### PR TITLE
Fix custom start issue

### DIFF
--- a/src/vmq_plugin_mgr.erl
+++ b/src/vmq_plugin_mgr.erl
@@ -475,7 +475,13 @@ start_plugins([]) -> ok.
 start_plugin(App) ->
     case lists:keyfind(App, 1, application:which_applications()) of
         false ->
-            case lists:member(App, erlang:loaded()) of
+            case lists:keyfind(App, 1, application:loaded_applications()) of
+                false ->
+                    application:load(App);
+                _ -> ok
+            end,
+            {ok, Mods} = application:get_key(App, modules),
+            case lists:member(App, Mods) of
                 true ->
                     %% does the App Module specifies a custom
                     %% start/1 function


### PR DESCRIPTION
I think the issue we've seen regarding the vmq_diversity plugin not being started the first time is due to the `case lists:member(App, erlang:loaded()) of` line. When no `App`  module is loaded it falls through to the `ensure_all_started` line. The second time around the `App` module has been loaded and the custom start function is being called.

I guess the `erlang:loaded` test was there to make sure we don't throw an exception. We probably need to rethink this.
